### PR TITLE
Fix code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -639,14 +639,20 @@ var ciDebugBar = {
 				form.setAttribute('data-debugbar-route-tpl', ciDebugBar.trimSlash(textInner.replace(patt, '?')));
 
 				// Safely add the inner text field
-				const textWithPlaceholder = textInner.replace(patt, (match, p1) => {
-					const input = document.createElement('input');
-					input.type = 'text';
-					input.placeholder = p1;
-					return input.outerHTML;
+				const fragments = textInner.split(patt);
+				fragments.forEach((fragment, index) => {
+					if (index % 2 === 0) {
+						// Add text fragment
+						const textNode = document.createTextNode(fragment);
+						form.appendChild(textNode);
+					} else {
+						// Add input field
+						const input = document.createElement('input');
+						input.type = 'text';
+						input.placeholder = fragment;
+						form.appendChild(input);
+					}
 				});
-				form.textContent = '';  // Clear any existing content
-				form.insertAdjacentHTML('beforeend', textWithPlaceholder);
 					
 				// Add the submit button
 				const submitButton = document.createElement('input');


### PR DESCRIPTION
Fixes [https://github.com/zayanit/select-box/security/code-scanning/7](https://github.com/zayanit/select-box/security/code-scanning/7)

To fix the problem, we need to ensure that any text extracted from the DOM and reinserted as HTML is properly sanitized or escaped to prevent XSS attacks. The best way to fix this issue is to avoid using `insertAdjacentHTML` with untrusted data and instead use safer methods to construct the HTML elements.

1. Replace the use of `insertAdjacentHTML` with a method that safely creates and appends the input elements.
2. Ensure that any text content is properly escaped before being inserted into the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
