### PR TITLE
Fix code scanning alert no. 5: Inefficient regular expression

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -612,7 +612,7 @@ var ciDebugBar = {
 	routerLink: function() {
 		var row, _location;
 		var rowGet = document.querySelectorAll('#debug-bar td[data-debugbar-route="GET"]');
-		var patt = /\(([^()]*|\([^()]*\))*\)/g;
+		var patt = /\((?:[^()]+|\([^()]*\))*\)/g;
 
 
 		for (var i = 0; i < rowGet.length; i++) {


### PR DESCRIPTION
Fixes [https://github.com/zayanit/select-box/security/code-scanning/5](https://github.com/zayanit/select-box/security/code-scanning/5)

To fix the problem, we need to modify the regular expression to avoid nested quantifiers that can lead to exponential backtracking. The goal is to ensure that the regex engine does not have to try multiple paths excessively.

The best way to fix this is to use a more specific pattern that avoids ambiguity. We can achieve this by using a non-capturing group and ensuring that the inner part of the regex does not match an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
