### PR TITLE
Fix code scanning alert no. 12: Inefficient regular expression

### DIFF
--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -612,7 +612,7 @@ var ciDebugBar = {
 	routerLink: function() {
 		var row, _location;
 		var rowGet = document.querySelectorAll('#debug-bar td[data-debugbar-route="GET"]');
-		var patt = /\((?:[^()]*|\((?:[^()]*|[^()])*\))*\)/g;
+		var patt = /\((?:[^()]*|\([^()]*\))*\)/g;
 
 
 		for (var i = 0; i < rowGet.length; i++) {

--- a/system/Debug/Toolbar/Views/toolbar.js
+++ b/system/Debug/Toolbar/Views/toolbar.js
@@ -612,7 +612,7 @@ var ciDebugBar = {
 	routerLink: function() {
 		var row, _location;
 		var rowGet = document.querySelectorAll('#debug-bar td[data-debugbar-route="GET"]');
-		var patt = /\((?:[^()]*|\([^()]*\))*\)/g;
+		var patt = /\((?:[^()]+|\([^()]*\))*\)/g;
 
 
 		for (var i = 0; i < rowGet.length; i++) {


### PR DESCRIPTION
Fixes [https://github.com/zayanit/select-box/security/code-scanning/12](https://github.com/zayanit/select-box/security/code-scanning/12)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we should avoid patterns like `[^()]*` that can match an empty string and lead to multiple ways to match the same input. Instead, we can use a more precise pattern that ensures each part of the input is matched in a single, unambiguous way.

The best way to fix this is to rewrite the regular expression to avoid nested quantifiers and ambiguous alternations. We can achieve this by using a non-capturing group and a more specific character class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
